### PR TITLE
#21: Refactor `get_value_of_jsonpath` to Rust

### DIFF
--- a/graphql_authz_proxy/_rust.py
+++ b/graphql_authz_proxy/_rust.py
@@ -34,6 +34,18 @@ def extract_user_from_headers(headers: object) -> tuple[str, str, str, list[str]
     return _native.extract_user_from_headers(headers)
 
 
+def get_value_of_jsonpath(data: object, path: str) -> object:
+    """Native JSONPath lookup.
+
+    Raises:
+        RuntimeError: If the native extension is not available.
+
+    """
+    if _native is None:
+        raise RuntimeError("Rust extension 'graphql_authz_proxy_rs' is not available")
+    return _native.get_value_of_jsonpath(data, path)
+
+
 def version() -> str:
     """Return the version reported by the native extension.
 

--- a/graphql_authz_proxy/authz/utils.py
+++ b/graphql_authz_proxy/authz/utils.py
@@ -23,6 +23,26 @@ from graphql_authz_proxy.models import FieldNodeDict, RenderedFields
 def get_value_of_jsonpath(data: dict, path: str) -> Any:  # noqa: ANN401
     """Get nested value from data using JSONPath notation.
 
+    Delegates to the native Rust implementation when the optional
+    ``graphql_authz_proxy_rs`` extension is built (see issue #21), and
+    transparently falls back to the pure-Python implementation otherwise.
+
+    Args:
+        data (dict): The data to search.
+        path (str): JSONPath string (without leading $).
+
+    Returns:
+        Any: The value(s) found, or None if not found.
+
+    """
+    if _rust.RUST_AVAILABLE:
+        return _rust.get_value_of_jsonpath(data, path)
+    return _get_value_of_jsonpath_py(data, path)
+
+
+def _get_value_of_jsonpath_py(data: dict, path: str) -> Any:  # noqa: ANN401
+    """Pure-Python reference implementation of :func:`get_value_of_jsonpath`.
+
     Args:
         data (dict): The data to search.
         path (str): JSONPath string (without leading $).

--- a/graphql_authz_proxy/tests/test_rust_interop.py
+++ b/graphql_authz_proxy/tests/test_rust_interop.py
@@ -18,7 +18,9 @@ import pytest
 from graphql_authz_proxy import _rust
 from graphql_authz_proxy.authz.utils import (
     _extract_user_from_headers_py,
+    _get_value_of_jsonpath_py,
     extract_user_from_headers,
+    get_value_of_jsonpath,
 )
 
 # A representative set of proxy headers as forwarded by oauth2-proxy.
@@ -72,3 +74,60 @@ def test_native_version_is_reported() -> None:
     version = _rust.version()
     assert isinstance(version, str)
     assert version
+
+
+# A collection of (data, path, expected) cases that both the pure-Python and
+# the native JSONPath implementations must agree on. These mirror the
+# behaviour of ``jsonpath_ng.parse(f"$.{path}")`` for the subset of JSONPath
+# used by the proxy (dotted field access, integer indices and wildcards).
+JSONPATH_CASES = [
+    # Falsy data or path short-circuit to None.
+    (None, "a", None),
+    ({}, "a", None),
+    ({"a": 1}, "", None),
+    # Simple and nested dotted field access.
+    ({"a": 1}, "a", 1),
+    ({"a": {"b": 5}}, "a.b", 5),
+    ({"a": {"b": {"c": "z"}}}, "a.b.c", "z"),
+    ({"a": "hello"}, "a", "hello"),
+    # A single match that is itself a list is returned as-is.
+    ({"a": [1, 2, 3]}, "a", [1, 2, 3]),
+    # Missing keys / traversing through scalars yield no match -> None.
+    ({"a": 1}, "a.b", None),
+    ({"a": {"b": 5}}, "a.x", None),
+    # Integer indices, including negative ones.
+    ({"a": [1, 2, 3]}, "a[0]", 1),
+    ({"a": [1, 2, 3]}, "a[-1]", 3),
+    ({"a": [1]}, "a[5]", None),
+    # Wildcards over lists and dict values.
+    ({"a": [1, 2, 3]}, "a[*]", [1, 2, 3]),
+    ({"a": [9]}, "a[*]", 9),
+    ({"a": {"x": 1, "y": 2}}, "a.*", [1, 2]),
+    # A value of None is a valid match and is returned as None.
+    ({"a": None}, "a", None),
+]
+
+
+@pytest.mark.parametrize(("data", "path", "expected"), JSONPATH_CASES)
+def test_get_value_of_jsonpath(data: object, path: str, expected: object) -> None:
+    """The public helper resolves JSONPath expressions to the expected value."""
+    assert get_value_of_jsonpath(data, path) == expected
+
+
+@pytest.mark.parametrize(("data", "path", "expected"), JSONPATH_CASES)
+def test_get_value_of_jsonpath_pure_python(data: object, path: str, expected: object) -> None:
+    """The pure-Python reference resolves JSONPath expressions identically."""
+    assert _get_value_of_jsonpath_py(data, path) == expected
+
+
+@pytest.mark.parametrize(("data", "path", "_expected"), JSONPATH_CASES)
+def test_public_jsonpath_matches_pure_python_reference(data: object, path: str, _expected: object) -> None:
+    """The public helper (Rust or not) matches the pure-Python reference."""
+    assert get_value_of_jsonpath(data, path) == _get_value_of_jsonpath_py(data, path)
+
+
+@pytest.mark.skipif(not _rust.RUST_AVAILABLE, reason="Rust extension not built")
+@pytest.mark.parametrize(("data", "path", "_expected"), JSONPATH_CASES)
+def test_native_jsonpath_matches_reference(data: object, path: str, _expected: object) -> None:
+    """When built, the native function matches the pure-Python reference."""
+    assert _rust.get_value_of_jsonpath(data, path) == _get_value_of_jsonpath_py(data, path)

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -8,6 +8,7 @@
 
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
 
 /// Parse a raw `X-Forwarded-Groups` header value into a list of group names.
 ///
@@ -45,6 +46,157 @@ fn extract_user_from_headers(
     Ok((user_email, user, access_token, groups))
 }
 
+/// A single step in a JSONPath expression.
+///
+/// Only the subset of JSONPath actually exercised by the proxy is modelled:
+/// dotted field access, integer indices (including negative ones) and
+/// wildcards (`a.*` / `a[*]`). Anything outside this grammar fails to parse,
+/// which the caller maps to "no match" -- mirroring how the pure-Python
+/// reference swallows `jsonpath_ng` errors and returns `None`.
+#[derive(Debug, PartialEq)]
+enum Step {
+    /// Access a mapping key by name.
+    Field(String),
+    /// Index into a sequence (negative indices count from the end).
+    Index(isize),
+    /// Match every element of a sequence or every value of a mapping.
+    Wildcard,
+}
+
+/// Parse a `$.`-relative JSONPath string into a list of [`Step`]s.
+///
+/// Returns `None` for any syntax outside the supported subset, so the caller
+/// can treat unparseable paths as a non-match.
+fn parse_path(path: &str) -> Option<Vec<Step>> {
+    let mut steps = Vec::new();
+    let bytes = path.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'.' => {
+                // A leading or doubled '.' (empty field name) is invalid.
+                i += 1;
+                let start = i;
+                while i < bytes.len() && bytes[i] != b'.' && bytes[i] != b'[' {
+                    i += 1;
+                }
+                let name = &path[start..i];
+                if name.is_empty() {
+                    return None;
+                }
+                steps.push(field_or_wildcard(name));
+            }
+            b'[' => {
+                let end = path[i..].find(']')? + i;
+                let inner = &path[i + 1..end];
+                steps.push(parse_bracket(inner)?);
+                i = end + 1;
+            }
+            _ => {
+                // The very first segment has no leading separator.
+                if !steps.is_empty() {
+                    return None;
+                }
+                let start = i;
+                while i < bytes.len() && bytes[i] != b'.' && bytes[i] != b'[' {
+                    i += 1;
+                }
+                steps.push(field_or_wildcard(&path[start..i]));
+            }
+        }
+    }
+    Some(steps)
+}
+
+/// Map a bare segment name to a [`Step::Wildcard`] or [`Step::Field`].
+fn field_or_wildcard(name: &str) -> Step {
+    if name == "*" {
+        Step::Wildcard
+    } else {
+        Step::Field(name.to_string())
+    }
+}
+
+/// Parse the contents of a `[...]` selector into a [`Step`].
+fn parse_bracket(inner: &str) -> Option<Step> {
+    if inner == "*" {
+        Some(Step::Wildcard)
+    } else {
+        inner.parse::<isize>().ok().map(Step::Index)
+    }
+}
+
+/// Recursively collect every value reachable from `data` via `steps`.
+fn collect_matches<'py>(
+    data: &Bound<'py, PyAny>,
+    steps: &[Step],
+    out: &mut Vec<Bound<'py, PyAny>>,
+) {
+    let Some((step, rest)) = steps.split_first() else {
+        out.push(data.clone());
+        return;
+    };
+    match step {
+        Step::Field(name) => {
+            if let Ok(dict) = data.downcast::<PyDict>() {
+                if let Ok(Some(value)) = dict.get_item(name) {
+                    collect_matches(&value, rest, out);
+                }
+            }
+        }
+        Step::Index(index) => {
+            if let Ok(list) = data.downcast::<PyList>() {
+                let len = list.len() as isize;
+                let resolved = if *index < 0 { index + len } else { *index };
+                if resolved >= 0 && resolved < len {
+                    if let Ok(value) = list.get_item(resolved as usize) {
+                        collect_matches(&value, rest, out);
+                    }
+                }
+            }
+        }
+        Step::Wildcard => {
+            if let Ok(list) = data.downcast::<PyList>() {
+                for value in list.iter() {
+                    collect_matches(&value, rest, out);
+                }
+            } else if let Ok(dict) = data.downcast::<PyDict>() {
+                for (_key, value) in dict.iter() {
+                    collect_matches(&value, rest, out);
+                }
+            }
+        }
+    }
+}
+
+/// Resolve a JSONPath expression against `data`, mirroring
+/// `graphql_authz_proxy.authz.utils.get_value_of_jsonpath`.
+///
+/// The `path` is the JSONPath body without the leading `$.`. Returns `None`
+/// when `data` or `path` is falsy, when the path does not parse, or when it
+/// matches nothing. A single match is returned unwrapped; multiple matches are
+/// returned as a list.
+#[pyfunction]
+fn get_value_of_jsonpath(
+    py: Python<'_>,
+    data: &Bound<'_, PyAny>,
+    path: &str,
+) -> PyResult<PyObject> {
+    if path.is_empty() || !data.is_truthy()? {
+        return Ok(py.None());
+    }
+    let Some(steps) = parse_path(path) else {
+        return Ok(py.None());
+    };
+    let mut matches = Vec::new();
+    collect_matches(data, &steps, &mut matches);
+    match matches.len() {
+        0 => Ok(py.None()),
+        1 => Ok(matches.into_iter().next().unwrap().unbind()),
+        _ => Ok(PyList::new(py, matches)?.into_any().unbind()),
+    }
+}
+
 /// Return the version of the native crate, for diagnostics/health checks.
 #[pyfunction]
 fn version() -> String {
@@ -56,6 +208,7 @@ fn version() -> String {
 fn graphql_authz_proxy_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_function(wrap_pyfunction!(extract_user_from_headers, m)?)?;
+    m.add_function(wrap_pyfunction!(get_value_of_jsonpath, m)?)?;
     m.add_function(wrap_pyfunction!(version, m)?)?;
     Ok(())
 }
@@ -81,5 +234,41 @@ mod tests {
     #[test]
     fn single_group_has_no_separator() {
         assert_eq!(parse_groups("admins"), vec!["admins"]);
+    }
+
+    #[test]
+    fn parses_dotted_field_path() {
+        assert_eq!(
+            parse_path("a.b.c"),
+            Some(vec![
+                Step::Field("a".into()),
+                Step::Field("b".into()),
+                Step::Field("c".into()),
+            ])
+        );
+    }
+
+    #[test]
+    fn parses_indices_and_wildcards() {
+        assert_eq!(
+            parse_path("a[0].b[-1].c[*]"),
+            Some(vec![
+                Step::Field("a".into()),
+                Step::Index(0),
+                Step::Field("b".into()),
+                Step::Index(-1),
+                Step::Field("c".into()),
+                Step::Wildcard,
+            ])
+        );
+        assert_eq!(parse_path("a.*"), Some(vec![Step::Field("a".into()), Step::Wildcard]));
+    }
+
+    #[test]
+    fn rejects_malformed_paths() {
+        // Doubled separators (empty field names) and unterminated brackets.
+        assert_eq!(parse_path("a..b"), None);
+        assert_eq!(parse_path("a["), None);
+        assert_eq!(parse_path("a[x]"), None);
     }
 }


### PR DESCRIPTION
Closes #21

Implemented by Worker Agent 2.

[View run logs](https://github.com/kgmcquate/graphql-authz-proxy/actions/runs/28325918617)